### PR TITLE
Completion for all local & fetched remote branches.

### DIFF
--- a/git_branch_autocomplete.lua
+++ b/git_branch_autocomplete.lua
@@ -23,7 +23,7 @@ function is_checkout_ac(text)
 end
 
 function get_branches()
-  local handle = io.popen("git branch -r 2>&1")
+  local handle = io.popen("git branch -a 2>&1")
   local result = handle:read("*a")
   handle:close()
 
@@ -31,7 +31,7 @@ function get_branches()
 
   if string.starts(result, "fatal") == false then
     for branch in string.gmatch(result, "  %S+") do
-      branch = string.gsub(branch, "  origin%/", "")
+      branch = string.gsub(branch, "  ", "")
 
       if branch ~= "HEAD" then
         table.insert(branches, branch)


### PR DESCRIPTION
The existing code uses `git branch -r`, which only lists remote
branches, and the gsub to strip `  origin/` from each result only pulls
the preceding formatting spaces out from remotes named origin, so other
remotes have their formatting spaces left in and no longer match the
names a user has typed. Local branches aren't involved at all.

These changes switch to `git branch -a`, which lists all local and
remote branches, and only strip the preceding two spaces from results,
which together make it so that all local and fetched remote branches
can be autocompleted (with remote branches requiring that you specify
them fully by including the name of the remote at their start).